### PR TITLE
Refactored delete statement to use IN statement instead of multiple OR statements

### DIFF
--- a/phpgsb.class.php
+++ b/phpgsb.class.php
@@ -532,7 +532,7 @@ class phpGSB
             if (count($buildprefixdel)) {
                 //Delete all matching hostkey prefixes
                 mysql_query(
-                    "DELETE FROM `$buildtrunk-prefixes` WHERE `Hostkey` in (" . implode(',', $buildprefixdel) . ")"
+                    "DELETE FROM `$buildtrunk-prefixes` WHERE `Hostkey` in ('" . implode('\',\'', $buildprefixdel) . "')"
                 );
             }
 				


### PR DESCRIPTION
In my test, the hostkey count reached > 300.000 entries. This generated on line 534 an sql statement containing also > 300.000 OR statements (ie DELETE FROM `goog-malware-shavar-a-prefixes` WHERE `Hostkey` ='1' OR `Hostkey` ='2' OR `Hostkey` ='3' OR `Hostkey` ='4' OR `Hostkey` ='5' OR `Hostkey` ='6' OR `Hostkey` ='7' OR ... )

For low numbers this will work, but for large numbers this will most likely crash (ie Mysql has gone away errors). Also while this query is still being processed, the entire table is locked! This is definitely not ok.

Refactored the multiple OR statements to a single IN statement which is much much faster and has no size limitations.
